### PR TITLE
Fix release workflow

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -12,8 +12,6 @@ jobs:
   release:
     name: Release new demo
     runs-on: ubuntu-20.04
-    env:
-      TAG_NAME: ${GITHUB_REF#refs/tags/}
     steps:
       - name: Checkout git repository 🕝
         uses: actions/checkout@v2
@@ -29,6 +27,9 @@ jobs:
         run: |
           # Set up docker to authenticate via gcloud command-line tool.
           gcloud auth configure-docker
+
+      - name: Get tag name
+        run: echo "TAG_NAME=${GITHUB_REF#refs/tags/}" >> $GITHUB_ENV
 
       - name: Build new image
         run: |


### PR DESCRIPTION
**The problem:**
The Env argument does not support Bash's parameter substitution. It reads `TAG_NAME: ${GITHUB_REF#refs/tags/}` [as it is](https://github.com/RasaHQ/rasa-x-demo/runs/3338082754?check_suite_focus=true#step:5:20). 


**The solution:**
Extract the tag name in a step and export it to env variable such that it can be used across the job. 