### PR TITLE
Disable scheduled workflow on forked repo

### DIFF
--- a/.github/workflows/rasaoss-version-bumper.yml
+++ b/.github/workflows/rasaoss-version-bumper.yml
@@ -5,6 +5,7 @@ on:
   schedule:
     # Run once a day at 08:00
     - cron: '0 8 * * *'
+  workflow_dispatch:
 
 
 jobs:

--- a/.github/workflows/rasaoss-version-bumper.yml
+++ b/.github/workflows/rasaoss-version-bumper.yml
@@ -11,6 +11,7 @@ on:
 jobs:
   bump_rasa_oss_version:
     runs-on: ubuntu-latest
+    if: github.repository_owner == 'RasaHQ'
 
     steps:
       - name: Authenticate GitHub CLI


### PR DESCRIPTION
GitHub action will automatically disable scheduled workflow on _new_ forked repos.

> Warning: To prevent unnecessary workflow runs, **scheduled workflows may be disabled automatically**. When a public repository is forked, scheduled workflows are disabled by default. In a public repository, scheduled workflows are automatically disabled when no repository activity has occurred in 60 days.
  reference: https://docs.github.com/en/asctions/managing-workflow-runs/disabling-and-enabling-a-workflow

See the yellow box:

![image](https://user-images.githubusercontent.com/26658608/130418105-6be7d411-c985-4fae-ab9e-4b6e085dc067.png)

But for old forks, when they merge the latest base branch, the scheduled workflow is still enabled and running. 

By explicitly set the condition of the workflow run only on  `RasaHQ`, we can prevent schedule workflows run on forks.

__Changes__
- Add an if condition on schedule workflow such that it will skip on forks
- Add a manual trigger - we may want this when we need to bump rasa version right away

__Test__ 
- [x] Make sure the workflow does not run on forked. See [here](https://github.com/HotThoughts/rasa-x-demo/actions).