### PR TITLE
Disable version bumping workflow on Rasa OSS 3.0 and above

### DIFF
--- a/.github/workflows/rasaoss-version-bumper.yml
+++ b/.github/workflows/rasaoss-version-bumper.yml
@@ -22,14 +22,28 @@ jobs:
 
       - name: Get the latest Rasa OSS version 🏷
         run: |
-          LATEST_RASA_VERSION=$(gh release list --repo github.com/RasaHQ/rasa --limit 10 | awk '{print $1}' | sort --version-sort -r | head -1)
+          # LATEST_RASA_VERSION=$(gh release list --repo github.com/RasaHQ/rasa --limit 10 | awk '{print $1}' | sort --version-sort -r | head -1)
+          # Debug: hardcode rasa version for testing
+          LATEST_RASA_VERSION=3.0.0
           echo "Latest Rasa OSS version: $LATEST_RASA_VERSION"
           echo "LATEST_RASA_VERSION=$LATEST_RASA_VERSION" >> $GITHUB_ENV
 
+      # keep this step util Rasa X supports Rasa OSS 3.0
+      - name: Don't bump Rasa OSS 3.0 and above
+        run: |
+          if [[ ${{ env.LATEST_RASA_VERSION }} =~ 3.** ]]; then
+            echo "Rasa X doesn't compatible with Rasa OSS 3.0 yet. Skip the bumping."
+            echo "BUMP_RASA=false" >> $GITHUB_ENV
+          else
+            echo "BUMP_RASA=true" >> $GITHUB_ENV
+          fi
+
       - name: Checkout repository 🕝
+        if: env.BUMP_RASA == 'true'
         uses: actions/checkout@v2
 
       - name: Is Rasa OSS version up to date❓
+        if: env.BUMP_RASA == 'true'
         run: |
           RASA_VERSION=$(sed -n 's/^rasa==//p' requirements.txt)
 

--- a/.github/workflows/rasaoss-version-bumper.yml
+++ b/.github/workflows/rasaoss-version-bumper.yml
@@ -22,9 +22,7 @@ jobs:
 
       - name: Get the latest Rasa OSS version 🏷
         run: |
-          # LATEST_RASA_VERSION=$(gh release list --repo github.com/RasaHQ/rasa --limit 10 | awk '{print $1}' | sort --version-sort -r | head -1)
-          # Debug: hardcode rasa version for testing
-          LATEST_RASA_VERSION=3.0.0
+          LATEST_RASA_VERSION=$(gh release list --repo github.com/RasaHQ/rasa --limit 10 | awk '{print $1}' | sort --version-sort -r | head -1)
           echo "Latest Rasa OSS version: $LATEST_RASA_VERSION"
           echo "LATEST_RASA_VERSION=$LATEST_RASA_VERSION" >> $GITHUB_ENV
 


### PR DESCRIPTION
Rasa OSS `3.0` is coming out soon but Rasa X doesn't compatible with `3.0` yet. We don't want to bump Rasa OSS to a version that Rasa X doesn't support.
 
Added a step to skip the version bumping workflow when the new Rasa OSS version is 3.0 and above. 

**Definition of Done:**
Don't bump Rasa OSS version when the new Rasa OSS is 3.0 and above. See [this](https://github.com/RasaHQ/rasa-x-demo/runs/4069125212?check_suite_focus=true) run, the rasa version is [hardcoded to `3.0.0`](https://github.com/RasaHQ/rasa-x-demo/runs/4069125212?check_suite_focus=true#step:3:4) and all the following steps are skipped.

Also, the [workflow](https://github.com/RasaHQ/rasa-x-demo/runs/4069125212?check_suite_focus=true) runs as normal when the Rasa OSS is `2.x`. 
