### PR TITLE
Replace Rasabot Token

### DIFF
--- a/.github/workflows/rasaoss-version-bumper.yml
+++ b/.github/workflows/rasaoss-version-bumper.yml
@@ -18,7 +18,7 @@ jobs:
         run: |
           # https://cli.github.com/manual/gh_auth_login
           # read token from standard input 
-          gh auth login --with-token <<< ${{ secrets.RASABOT_GITHUB_TOKEN }}
+          gh auth login --with-token <<< ${{ secrets.GITHUB_TOKEN }}
 
       - name: Get the latest Rasa OSS version 🏷
         run: |


### PR DESCRIPTION
Replace the Rasabot PAT with the in-built `GITHUB_TOKEN`.